### PR TITLE
some fixes

### DIFF
--- a/i386/i386/cpuboot.S
+++ b/i386/i386/cpuboot.S
@@ -86,7 +86,7 @@ _apboot:
 	movw	%ax,%ss
 
 	/* Load cpu stack */
-	movl stack_ptr, %esp
+	movl (stack_ptr), %esp
 	addl $STACK_SIZE, %esp
 
 	/* Reset EFLAGS to a known state.  */

--- a/i386/i386/mp_desc.c
+++ b/i386/i386/mp_desc.c
@@ -475,10 +475,13 @@ interrupt_stack_alloc(void)
      * Allocate an interrupt stack for each CPU except for
      * the master CPU (which uses the bootstrap stack)
      */
-    if (!init_alloc_aligned(INTSTACK_SIZE*(ncpu-1), &stack_start))
-        panic("not enough memory for interrupt stacks");
-    stack_start = phystokv(stack_start);
 
+	if(ncpu > 1){
+		if (!init_alloc_aligned(INTSTACK_SIZE*(ncpu-1), &stack_start))
+        	panic("not enough memory for interrupt stacks");
+	    stack_start = phystokv(stack_start);
+	}
+    
     /*
      * Set up pointers to the top of the interrupt stack.
      */
@@ -502,7 +505,7 @@ interrupt_stack_alloc(void)
      * Set up the barrier address.  All thread stacks MUST
      * be above this address.
      */
-    int_stack_high = stack_start;
+    if(ncpu > 1) int_stack_high = stack_start;
 }
 
 /* XXX should be adjusted per CPU speed */

--- a/i386/i386/mp_desc.c
+++ b/i386/i386/mp_desc.c
@@ -73,8 +73,8 @@ vm_offset_t	int_stack_high;
 /*
  * First cpu`s interrupt stack.
  */
-char		intstack[];	/* bottom */
-char		eintstack[];	/* top */
+extern char		_intstack[];	/* bottom */
+extern char		_eintstack[];	/* top */
 
 
 /*
@@ -486,8 +486,8 @@ interrupt_stack_alloc(void)
         {
             if (i == master_cpu)
                 {
-                    interrupt_stack[i] = (vm_offset_t) intstack;
-                    _int_stack_top[i]   = (vm_offset_t) eintstack;
+                    interrupt_stack[i] = (vm_offset_t) _intstack;
+                    _int_stack_top[i]   = (vm_offset_t) _intstack + INTSTACK_SIZE;
                 }
             else if (machine_slot[i].is_cpu)
                 {

--- a/i386/i386at/model_dep.c
+++ b/i386/i386at/model_dep.c
@@ -522,6 +522,7 @@ i386at_init(void)
     ldt_init();
     ktss_init();
 
+    interrupt_stack_alloc();
     mp_desc_init(master_cpu);
 
 


### PR DESCRIPTION
Fixed `interrupt_stack_alloc()` function:
   - renamed `intstack` to `_intstack`, and declared as extern
   - added some guards to avoid memory reserve when `ncpu == 1`

Fixed `esp` loading
   - fix syntax error in access to memory pointed by `stack_ptr` in assembly